### PR TITLE
Enable external support from plugins

### DIFF
--- a/implementations/src/main/java/me/andrew28/addons/conquer/factions/FactionsPluginType.java
+++ b/implementations/src/main/java/me/andrew28/addons/conquer/factions/FactionsPluginType.java
@@ -11,7 +11,9 @@ public enum FactionsPluginType {
     ORIGINAL("Original Factions (Massive Core)", FactionsImpl.class),
     FACTIONS_ONE("Factions One (Sataniel)", null),
     FACTIONS_UUID("Factions UUID (drtshock)", FactionsUUIDImpl.class),
-    KINGDOMS("Kingdoms (Hex_27)", null);
+    KINGDOMS("Kingdoms (Hex_27)", null),
+    OTHER("Other", null);
+	
     String friendlyName;
     Class<? extends FactionsPlugin> pluginImpl;
 

--- a/plugin/src/main/java/me/andrew28/addons/conquer/Conquer.java
+++ b/plugin/src/main/java/me/andrew28/addons/conquer/Conquer.java
@@ -14,8 +14,8 @@ import java.util.Arrays;
 public class Conquer extends Addon{
     private static Conquer instance;
 
-    private FactionsPlugin factionsPlugin;
-    private FactionsPluginType factionsPluginType;
+    private FactionsPlugin factionsPlugin = null;
+    private FactionsPluginType factionsPluginType = null;
     public static Conquer getInstance() {
         return instance;
     }
@@ -74,4 +74,21 @@ public class Conquer extends Addon{
     public FactionsPluginType getFactionsPluginType() {
         return factionsPluginType;
     }
+    
+    /**
+     * Set the faction plugin class to use.
+     * @param factionsPlugin The faction plugin class to use.
+     */
+    public void setFactionsPlugin(FactionsPlugin factionsPlugin) {
+        this.factionsPlugin = factionsPlugin;
+    }
+    
+    /**
+     * Set the faction plugin type.
+     * @param factionsPluginType The faction plugin type.
+     */
+    public void setFactionsPluginType(FactionsPluginType factionsPluginType) {
+        this.factionsPluginType = factionsPluginType;
+    }
+    
 }

--- a/plugin/src/main/java/me/andrew28/addons/conquer/skript/expressions/ExprFactionsImplementationName.java
+++ b/plugin/src/main/java/me/andrew28/addons/conquer/skript/expressions/ExprFactionsImplementationName.java
@@ -19,6 +19,9 @@ import me.andrew28.addons.core.annotations.*;
 public class ExprFactionsImplementationName extends ASAExpression<String>{
     @Override
     public String getValue() throws NullExpressionException {
+        if (Conquer.getInstance().getFactionsPluginType() == null){
+        	    return "None";
+        }
         return Conquer.getInstance().getFactionsPluginType().getFriendlyName();
     }
 }

--- a/plugin/src/main/java/me/andrew28/addons/conquer/skript/expressions/ExprFactionsImplementationName.java
+++ b/plugin/src/main/java/me/andrew28/addons/conquer/skript/expressions/ExprFactionsImplementationName.java
@@ -20,7 +20,7 @@ public class ExprFactionsImplementationName extends ASAExpression<String>{
     @Override
     public String getValue() throws NullExpressionException {
         if (Conquer.getInstance().getFactionsPluginType() == null){
-        	    return "None";
+        	    return null;
         }
         return Conquer.getInstance().getFactionsPluginType().getFriendlyName();
     }


### PR DESCRIPTION
This is a simple PR that will enable external support from plugins. I think this will be a great addition to Conquer! 

This will allow external plugins to easily add support for Conquer - which in the future, means a Skript created with Conquer will be _truely_ universal without limits.

For growing conquer style plugins (like LegacyFactions) they will find this a nice way for their plugin to grow. 

I tried my best to stick to the style you had but if not let me know and I'll amend my commits! 